### PR TITLE
Fix for Eris 0.8.0

### DIFF
--- a/src/PlayerManager.js
+++ b/src/PlayerManager.js
@@ -246,7 +246,7 @@ class PlayerManager extends Collection {
                 };
 
                 let shard = this.client.shards.get(message.shardId);
-                if (shard && shard.status === 'connected') {
+                if (shard && (shard.status === 'connected' || shard.status === 'ready')) {
                     payload.connected = true;
                 }
 


### PR DESCRIPTION
Eris 0.8.0 changed `connected` to be `ready`.. this works with 0.7.0 and 0.8.0